### PR TITLE
Unit and quantity name pedantry

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 			<h3 id="grey-text">Quit fucking around with grey text.</h3>
 			<p><a title="Contrast Rebellion" href="http://contrastrebellion.com/">Text contrast is not a bad thing</a>. The print on your newspaper is not true black, nor is the text on your screen. These are limitations, not ideals. Stop making it worse.</p>
 			<h3 id="remote-fonts">Remote fonts are wasting your time and mine.</h3>
-			<p>Why the fuck are you loading 500KB of font to render 50KB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="https://web.archive.org/web/20150303130927/http://www.awayback.com/revised-font-stack" title="Revised Font Stack">font stack your users already have</a>.</p>
+			<p>Why the fuck are you loading 500kB of font to render 50kB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="https://web.archive.org/web/20150303130927/http://www.awayback.com/revised-font-stack" title="Revised Font Stack">font stack your users already have</a>.</p>
 		</section>
 		<section>
 			<h2>Your website is more than just HTML.</h2>

--- a/index.html
+++ b/index.html
@@ -35,19 +35,19 @@
 				<li>Fits on all your shitty screens.</li>
 				<li>Looks the same in all your shitty browsers.</li>
 				<li>Accessible to every asshole that visits your site.</li>
-				<li>Shit’s legible and gets the fucking point across (if you had one instead of just a 5mb background video of hipsters poking at their iPhones).</li>
+				<li>Shit’s legible and gets the fucking point across (if you had one instead of just a 5MB background video of hipsters poking at their iPhones).</li>
 			</ul>
 			<p>You do it every day. You take <a title="Motherfucking Website" href="http://motherfuckingwebsite.com/">a fucking masterpiece</a> and incrementally <a href="http://bettermotherfuckingwebsite.com" title="Better Motherfucking Website">ruin it</a> for the sake of design. Let me remind you: design is <dfn title="design">to plan and make something for a specific purpose</dfn>. The most basic purpose of text on a website is to be read. Yet you keep doing shit that gets in the way.</p>
 			<h3 id="grey-text">Quit fucking around with grey text.</h3>
 			<p><a title="Contrast Rebellion" href="http://contrastrebellion.com/">Text contrast is not a bad thing</a>. The print on your newspaper is not true black, nor is the text on your screen. These are limitations, not ideals. Stop making it worse.</p>
 			<h3 id="remote-fonts">Remote fonts are wasting your time and mine.</h3>
-			<p>Why the fuck are you loading 500K of font to render 50K of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="https://web.archive.org/web/20150303130927/http://www.awayback.com/revised-font-stack" title="Revised Font Stack">font stack your users already have</a>.</p>
+			<p>Why the fuck are you loading 500KB of font to render 50KB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="https://web.archive.org/web/20150303130927/http://www.awayback.com/revised-font-stack" title="Revised Font Stack">font stack your users already have</a>.</p>
 		</section>
 		<section>
 			<h2>Your website is more than just HTML.</h2>
 			<h3 id="use-https">You have no excuse for using HTTP.</h3>
 			<p>Why are you still delivering sites over HTTP? My shitty Atom 330 CPU from 2008 can perform aes-256-cbc encryption via OpenSSL at 110 megabits per second. My Xeon E5-2670 CPU without AES-NI enabled hits 444 megabits per second. With AES-NI enabled it hits a staggering 2.2 gigabits per second. Your server probably can’t even load your stupid fucking Javascript framework’s dependencies that fast.</p>
-			<p>TLS certificates are cheap. Seriously, you can <a href="https://www.namecheap.com/security/ssl-certificates/comodo/positivessl.aspx?aff=90742" title="COMODO PositiveSSL Certificate via Namecheap">get them for $9 USD</a>. You paid twice that much for your idiotic domain name. You can even get them for free from <a href="https://letsencrypt.org/" title="Let’s Encrypt Free Certificate Authority">Let’s Encrypt</a>.</p>
+			<p>TLS certificates are cheap. Seriously, you can <a href="https://www.namecheap.com/security/ssl-certificates/comodo/positivessl.aspx?aff=90742" title="COMODO PositiveSSL Certificate via Namecheap">get them for US$9</a>. You paid twice that much for your idiotic domain name. You can even get them for free from <a href="https://letsencrypt.org/" title="Let’s Encrypt Free Certificate Authority">Let’s Encrypt</a>.</p>
 			<h3 id="compression">This shit is gzipped.</h3>
 			<p>Your webserver is perfectly capable of compressing HTML. My Atom 330 CPU can perform single-core <code>gzip -6</code> on random data at 51 megabits per second. My Xeon E5-2670 from 2012 can do this at 216 megabits per second. Your meme website isn’t as random as you think it is and will compress much faster.</p>
 			<h3 id="caching">Cache is Money</h3>


### PR DESCRIPTION
'MB' is the IEC-approved short form of 'megabyte', and 'kB' likewise 'kilobyte'. Replace '$9 USD' (9 dollars US dollars) with 'US$9'.