### PR TITLE
style <pre> elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,18 @@
 <title>Best Motherfucking Website</title>
 <style>
 	body{
+		font:1.2em/1.62 sans-serif;
 		margin:1em auto;
 		max-width:40em;
 		padding:0 .62em;
-		font:1.2em/1.62 sans-serif;
 	}
 	h1,h2,h3 {
 		line-height:1.2;
 	}
   pre {
-    padding: 0.5em;
-    overflow: auto;
+    background:#F8F8F8;
+    overflow:auto;
+    padding:.5em;
   }
 	@media print{
 		body{
@@ -42,6 +43,16 @@
 	<p><a title="Contrast Rebellion" href="http://contrastrebellion.com/">Text contrast is not a bad thing</a>. The print on your newspaper is not true black, nor is the text on your screen. These are limitations, not ideals. Stop making it worse.
 	<h3 id="remote-fonts">Remote fonts are wasting your time and mine.</h3>
 	<p>Why the fuck are you loading 500kB of font to render 50kB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="http://www.awayback.com/index.php/2010/02/03/revised-font-stack/" title="Revised Font Stack">font stack your users already have</a>.
+  <h3 id="stylesheet">Look at this fucking stylesheet.</h3>
+  <p><pre><code>&lt;style&gt;
+body{font:1.2em/1.62 sans-serif;margin:1em auto;max-width:40em;padding:0 .62em;}
+h1,h2,h3{line-height:1.2;}
+pre{background:#F8F8F8;overflow:auto;padding:.5em;}
+@media print{body{max-width:none}}
+&lt;/style&gt;</code></pre></p>
+  <p>Six lines. 214 bytes. This fits within <a href="https://tools.ietf.org/html/rfc879#section-1">the default TCP maximum segment size</a>, so this fucking stylesheet gets delivered fast.</p>
+  <p>Why do you need 30 megabytes of fucking node.js modules to minify your shitty CSS?</p>
+  <p><pre><code>&lt;style&gt;body{font:1.2em/1.62 sans-serif;margin:1em auto;max-width:40em;padding:0 .62  em;}h1,h2,h3{line-height:1.2;}pre{background:#F8F8F8;overflow:auto;padding:.5em;}@media print{body{max-width:none}}&lt;/style&gt;</code></pre></p>
 	<h2>Your website is more than just HTML.</h2>
 	<h3 id="use-https">You have no excuse for using HTTP.</h3>
 	<p>Why are you still delivering sites over HTTP? My shitty Atom 330 CPU from 2008 can perform aes-256-cbc encryption via OpenSSL at 110 megabits per second. My Xeon E5-2670 CPU without AES-NI enabled hits 444 megabits per second. With AES-NI enabled it hits a staggering 2.2 gigabits per second. Your server probably can’t even load your stupid fucking Javascript framework’s dependencies that fast.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
 	h1,h2,h3 {
 		line-height:1.2;
 	}
+  pre {
+    padding: 0.5em;
+    overflow: auto;
+  }
 	@media print{
 		body{
 			max-width:none


### PR DESCRIPTION
Displaying code blocks in the `<pre><code>...</code></pre>` format would cause the entire fucking page to scroll.  By styling the `<pre>` element with `overflow: auto` we constrain the size of the block to the column, and scroll just within that fucking block.

I included some fucking padding, but feel free to strip that out.  Or feel free to add a fucking background color, to fucking disambiguate preformatted sections from the rest.