### PR TITLE
Replace unsafe inline-src with sha hash

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,4 +1,4 @@
 /*
 	X-Content-Type-Options: nosniff
-	Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; sandbox
+	Content-Security-Policy: default-src 'none'; style-src 'sha256-IdQjnfDbRTcCGDI1cPGRVDvxSp5Y8qFq0elgnqC0b8k='; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; sandbox
 	Cache-Control: public; max-age=259200


### PR DESCRIPTION
I  used
`echo -n "
	@media (prefers-color-scheme: dark){
		body {color:#fff;background:#000}
		a:link {color:#cdf}
		a:hover, a:visited:hover {color:#def}
		a:visited {color:#dcf}
	}
	body{
		margin:1em auto;
		max-width:40em;
		padding:0 .62em;
		font:1.2em/1.62 sans-serif
	}
	h1,h2,h3 {
		line-height:1.2
	}
	@media print{
		body{
			max-width:none
		}
	}
" | openssl dgst -sha256 -binary | openssl enc -base64`
as suggested by [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles).

Works fine on my end: https://test.gamingboard.eu/

Edit:
Okay, the code function removes the indentation, which is crucial for a correct hash...