### PR TITLE
Improved css for color scheme and more

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <style>
 	:root{
 		color-scheme: light dark
+	}
 	body{
 		margin:1em auto;
 		max-width:40em;

--- a/index.html
+++ b/index.html
@@ -4,12 +4,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Best Motherfucking Website</title>
 <style>
+	:root{
+		color-scheme: light dark
 	body{
 		margin:1em auto;
 		max-width:40em;
 		padding:0 .62em;
-		font:1.2em/1.62 sans-serif;
-		color-scheme: light dark;
+		font:1.2em/1.62 sans-serif
 	}
 	h1,h2,h3 {
 		line-height:1.2

--- a/index.html
+++ b/index.html
@@ -2,20 +2,14 @@
 <html lang="en">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="icon" type="image/png" href="data:image/png;base64,">
 <title>Best Motherfucking Website</title>
 <style>
-	@media (prefers-color-scheme: dark){
-		body {color:#fff;background:#000}
-		a:link {color:#cdf}
-		a:hover, a:visited:hover {color:#def}
-		a:visited {color:#dcf}
-	}
 	body{
 		margin:1em auto;
 		max-width:40em;
 		padding:0 .62em;
-		font:1.2em/1.62 sans-serif
+		font:1.2em/1.62 sans-serif;
+		color-scheme: light dark;
 	}
 	h1,h2,h3 {
 		line-height:1.2
@@ -40,16 +34,16 @@
 		<li>Accessible to every asshole that visits your site.
 		<li>Shit’s legible and gets the fucking point across (if you had one instead of just a 5MB background video of hipsters poking at their iPhones).
 	</ul>
-	<p>You do it every day. You take <a title="Motherfucking Website" href="http://motherfuckingwebsite.com/">a fucking masterpiece</a> and incrementally <a href="http://bettermotherfuckingwebsite.com" title="Better Motherfucking Website">ruin it</a> for the sake of design. Let me remind you: design is <dfn title="design">to plan and make something for a specific purpose</dfn>. The most basic purpose of text on a website is to be read. Yet you keep doing shit that gets in the way.
+	<p>You do it every day. You take <a title="Motherfucking Website" href="//motherfuckingwebsite.com/">a fucking masterpiece</a> and incrementally <a href="//bettermotherfuckingwebsite.com" title="Better Motherfucking Website">ruin it</a> for the sake of design. Let me remind you: design is <dfn title="design">to plan and make something for a specific purpose</dfn>. The most basic purpose of text on a website is to be read. Yet you keep doing shit that gets in the way.
 	<h3 id="grey-text">Quit fucking around with grey text.</h3>
-	<p><a title="Contrast Rebellion" href="https://contrastrebellion.com/">Text contrast is not a bad thing</a>. The print on your newspaper is not true black, nor is the text on your screen. These are limitations, not ideals. Stop making it worse.
+	<p><a title="Contrast Rebellion" href="//contrastrebellion.com/">Text contrast is not a bad thing</a>. The print on your newspaper is not true black, nor is the text on your screen. These are limitations, not ideals. Stop making it worse.
 	<h3 id="remote-fonts">Remote fonts are wasting your time and mine.</h3>
-	<p>Why the fuck are you loading 500kB of font to render 50kB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="https://www.awayback.com/index.php/2010/02/03/revised-font-stack/" title="Revised Font Stack">font stack your users already have</a>.
+	<p>Why the fuck are you loading 500kB of font to render 50kB of shitty content? Are your users even going to notice that it’s not their default serif or sans-serif? Why do you even bother when Chrome is going to render it like ass anyways? Use a <a href="//www.awayback.com/index.php/2010/02/03/revised-font-stack/" title="Revised Font Stack">font stack your users already have</a>.
 	<h2>Your website is more than just HTML.</h2>
 	<h3 id="use-https">You have no excuse for using HTTP.</h3>
 	<p>Why are you still delivering sites over HTTP? My shitty Atom 330 CPU from 2008 can perform aes-256-cbc encryption via OpenSSL at 110 megabits per second. My Xeon E5-2670 CPU without AES-NI enabled hits 444 megabits per second. With AES-NI enabled it hits a staggering 2.2 gigabits per second. Your server probably can’t even load your stupid fucking JavaScript framework’s dependencies that fast.
-	<p>TLS certificates are cheap. Seriously, you can <a href="https://www.namecheap.com/security/ssl-certificates/comodo/positivessl" title="COMODO PositiveSSL Certificate via Namecheap">get them for US$6</a>. You paid twice that much for your idiotic domain name. You can even get them for free from <a href="https://letsencrypt.org/" title="Let’s Encrypt Free Certificate Authority">Let’s Encrypt</a>.
-	<p>HTTPS <a href="https://webmasters.googleblog.com/2014/08/https-as-ranking-signal.html" title="Google announces HTTPS support to affect pagerank">improves your search ranking</a> so people are more likely to find your ramblings on the Google. It’s also required for <a href="https://http2.github.io/faq/#does-http2-require-encryption" title="HTTP/2 Frequently Asked Questions">HTTP/2 support</a> which allows browsers to fetch resources more efficiently.
+	<p>TLS certificates are cheap. Seriously, you can <a href="//www.namecheap.com/security/ssl-certificates/comodo/positivessl" title="COMODO PositiveSSL Certificate via Namecheap">get them for US$6</a>. You paid twice that much for your idiotic domain name. You can even get them for free from <a href="//letsencrypt.org/" title="Let’s Encrypt Free Certificate Authority">Let’s Encrypt</a>.
+	<p>HTTPS <a href="//webmasters.googleblog.com/2014/08/https-as-ranking-signal.html" title="Google announces HTTPS support to affect pagerank">improves your search ranking</a> so people are more likely to find your ramblings on the Google. It’s also required for <a href="//http2.github.io/faq/#does-http2-require-encryption" title="HTTP/2 Frequently Asked Questions">HTTP/2 support</a> which allows browsers to fetch resources more efficiently.
 	<h3 id="compression">This shit is gzipped.</h3>
 	<p>Your webserver is perfectly capable of compressing HTML. My Atom 330 CPU can perform single-core <code>gzip -6</code> on random data at 51 megabits per second. My Xeon E5-2670 from 2012 can do this at 216 megabits per second. Your meme website isn’t as random as you think it is and will compress much faster.
 	<h3 id="caching">Cache is Money</h3>
@@ -59,5 +53,5 @@
 	<h3>Yes, this is fucking satire, you fuck</h3>
 	<p>I’m not actually saying your shitty site should look like this. What I’m saying is that all the problems we have with websites are <strong>ones we create ourselves</strong>. Websites aren’t broken by default, they are functional, high-performing, and accessible. You break them. You son-of-a-bitch.
 	<h2>Even the best can be improved.</h2>
-	<p>If you can bring this website further beyond perfection, <a href="https://github.com/KeenRivals/bestmotherfucking.website" title="KeenRivals/bestmotherfucking.website on GitHub">send a pull request on GitHub</a>.
+	<p>If you can bring this website further beyond perfection, <a href="//github.com/KeenRivals/bestmotherfucking.website" title="KeenRivals/bestmotherfucking.website on GitHub">send a pull request on GitHub</a>.
 </article>


### PR DESCRIPTION
# Removed unnecessary css using prefers-color-scheme and added color-scheme property
It lets browser choose their own color scheme to look more consistent but it may have different shades in different browsers so you may deny this as one of features of your website is extreme contrast
# Removed https before link in a tags 
All browsers go to https by default
# Removed unnecessary line for favicon
Demo is at https://pritkr.github.io/bestmotherfucking.website/